### PR TITLE
feat: add path support

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -9,19 +9,23 @@ module.exports = {
     const {
       parameters,
       template: { generate },
-      print: { error },
+      print: { error, info },
     } = toolbox
 
     try {
+      const path = parameters.options.path ?? 'src/components'
+
       const typeTranslated = typeTranslator({
         type: parameters.options.type,
         generate,
         generatedName: parameters.first,
         generateTestFile: parameters.options.test,
         language: parameters.second ?? 'ts',
+        path,
       })
 
       await Promise.all(typeTranslated.filesToCreate)
+      info(`Template generated successfully at folder ${path}.`)
     } catch (err) {
       error(err.message)
     }

--- a/src/commands/react-modest-cli.ts
+++ b/src/commands/react-modest-cli.ts
@@ -13,7 +13,7 @@ const command: GluegunCommand = {
         [
           'Create',
           'c | create',
-          '<name> <language> --type=<available_type> --test',
+          '<name> <language> --type=<available_type> --path=<component_path> --test',
         ],
       ],
       {

--- a/src/helpers/params-validation.ts
+++ b/src/helpers/params-validation.ts
@@ -1,17 +1,33 @@
+import { template } from './map-template-according-to-language'
+
 type validateInputedParamsProps = {
+  language: string
+  type: string
   generatedName?: string
-  typeTranslatorExists?: boolean
-  typeTranslatorKeys: Array<string>
 }
 
 export function validateInputedParams({
+  language,
+  type,
   generatedName,
-  typeTranslatorExists,
-  typeTranslatorKeys,
 }: validateInputedParamsProps): void {
-  if (!generatedName) throw new Error('A component name should be provided.')
-  if (!typeTranslatorExists)
+  const supportedLanguages = ['ts', 'typescript', 'js', 'javascript']
+
+  if (!supportedLanguages.includes(language))
     throw new Error(
-      `Invalid type paramter. Try one of ${typeTranslatorKeys.join(', ')}.`
+      `Unsuported language. Please insert one of these keys: ${supportedLanguages.join(
+        ', '
+      )}.`
+    )
+
+  if (!generatedName) throw new Error('A component name should be provided.')
+
+  const typeTranslator = template[language].get(type)
+
+  if (!typeTranslator)
+    throw new Error(
+      `Invalid type paramter. Try one of these keys: ${Array.from(
+        typeTranslator.keys()
+      ).join(', ')}.`
     )
 }

--- a/src/helpers/template-generator.ts
+++ b/src/helpers/template-generator.ts
@@ -9,6 +9,7 @@ type typeTranslatorProps = {
   generatedName?: string
   generateTestFile?: boolean
   language: string
+  path: string
 }
 
 type availableLanguages = 'ts' | 'js' | 'javascript' | 'typescript'
@@ -19,16 +20,17 @@ const typeTranslator = ({
   generatedName,
   generateTestFile,
   language,
+  path,
 }: typeTranslatorProps): {
   filesToCreate: Promise<string>[]
 } => {
-  const typeTranslator = template[language as availableLanguages].get(type)
-
   validateInputedParams({
     generatedName,
-    typeTranslatorExists: Boolean(typeTranslator),
-    typeTranslatorKeys: Array.from(template[language].keys()),
+    type,
+    language,
   })
+
+  const typeTranslator = template[language as availableLanguages].get(type)
 
   const filesToCreate = typeTranslator?.filesToCreate.map((file) => {
     return generate({
@@ -37,7 +39,7 @@ const typeTranslator = ({
         imports: file.importLines ?? [],
       },
       template: file.model,
-      target: `src/model/${file.fileName ?? generatedName}.${file.extension}`,
+      target: `${path}/${file.fileName ?? generatedName}.${file.extension}`,
     })
   })
 
@@ -50,8 +52,8 @@ const typeTranslator = ({
         },
         target:
           language === 'js' || language === 'javascript'
-            ? `src/model/${generatedName}.spec.jsx`
-            : `src/model/${generatedName}.spec.tsx`,
+            ? `${path}/${generatedName}.spec.jsx`
+            : `${path}/${generatedName}.spec.tsx`,
       })
     )
   }


### PR DESCRIPTION
### :octopus: What this PR does?
This PRs add path support on command line, to allow user to type where component should be created. If path option isn't provided by the user, the template will be generated at `src/components`. 

### :lady_beetle: Tasks done
- [x] Bug fix when user types an nonexistent `language`
- [x] Add `--path` option support 
- [x] Change validation function to be more isolated and assertive  